### PR TITLE
Support Inventory Changes in `testnet-deploy`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,6 @@ inputs:
     required: false
   safenode-features:
     description: Comma-separated list of features to be used when building a branch of safenode
-  safe-version:
-    description: Supply a version for safe. Otherwise the latest will be used.
   safenode-version:
     description: Supply a version for safenode. Otherwise the latest will be used.
   safenode-manager-version:
@@ -180,7 +178,6 @@ runs:
         PUBLIC_RPC: ${{ inputs.public-rpc }}
         RETRY_ATTEMPTS: ${{ inputs.re-attempts }}
         RUST_LOG: ${{ inputs.rust-log }}
-        SAFE_VERSION: ${{ inputs.safe-version }}
         SAFENODE_FEATURES: ${{ inputs.safenode-features }}
         SAFENODE_VERSION: ${{ inputs.safenode-version }}
         SAFENODE_MANAGER_VERSION: ${{ inputs.safenode-manager-version }}
@@ -203,7 +200,6 @@ runs:
         [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION"
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc"
         [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION"
-        [[ -n $SAFE_VERSION ]] && command="$command --safe-version $SAFE_VERSION"
         [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES"
         [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION"
         [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -203,6 +203,7 @@ runs:
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose"
         [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION"
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc"
+        [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION"
         [[ -n $SAFE_VERSION ]] && command="$command --safe-version $SAFE_VERSION"
         [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES"
         [[ -n $SAFENODE_VERSION ]] && command="$command --safenode-version $SAFENODE_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -379,14 +379,10 @@ runs:
     - name: Fetch inventory
       if: inputs.action == 'list-inventory'
       env:
-        NODE_COUNT: ${{ inputs.node-count }}
         PROVIDER: ${{ inputs.provider }}
         RETRY_ATTEMPTS: ${{ inputs.re-attempts }}
         RUST_LOG: ${{ inputs.rust-log }}
-        SAFE_NETWORK_BRANCH: ${{ inputs.safe-network-branch }}
-        SAFE_NETWORK_USER: ${{ inputs.safe-network-user }}
         TESTNET_NAME: ${{ inputs.testnet-name }}
-        VM_COUNT: ${{ inputs.vm-count }}
       shell: bash
       run: |
         set -e
@@ -397,19 +393,7 @@ runs:
           echo "Attempt $i of $max_attempts"
           
           set +e # Temporarily turn off 'exit on error'
-          if [[ -n $SAFE_NETWORK_USER ]]; then
-            cargo run -- inventory \
-              --name "$TESTNET_NAME" \
-              --provider "$PROVIDER" \
-              --node-count $NODE_COUNT \
-              --repo-owner $SAFE_NETWORK_USER \
-              --branch $SAFE_NETWORK_BRANCH
-          else
-            cargo run -- inventory \
-              --name "$TESTNET_NAME" \
-              --provider "$PROVIDER" \
-              --node-count $NODE_COUNT
-
+          cargo run -- inventory --name "$TESTNET_NAME" --provider "$PROVIDER"
           result=$?
           set -e # Re-enable 'exit on error'
 

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,6 @@ runs:
         terraform_wrapper: false
 
     - name: Install tools
-      if: inputs.action == 'create'
       shell: bash
       run: |
         sudo apt-get update -y


### PR DESCRIPTION
- b81c822 **fix: apply the faucet version number**

  This was missed the first time.

- a3bb256 **chore: always run tool installation**

  This ensures a specific version of Ansible will be installed, which is necessary for parsing the
  inventory for Digital Ocean on the print inventory workflow.

- c1be0a9 **chore: remove unnecessary args from `list-inventory`**

  The branch and node count arguments no longer apply to this command, so there is no need to supply
  them for this action.
  
- 263b0d8 **chore: remove `safe-version` input**

  The --safe-version argument was removed from the `deploy` command on `testnet-deploy` and therefore
  it is no longer necessary on this action.  