### PR TITLE
chore: use network contacts file name for inv cmd

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -429,11 +429,15 @@ runs:
       if: inputs.action == 'print-inventory'
       env:
         PROVIDER: ${{ inputs.provider }}
+        NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
         TESTNET_NAME: ${{ inputs.testnet-name }}
       shell: bash
       run: |
         cd ~/sn-testnet-deploy
-        cargo run -- inventory --name $TESTNET_NAME --force-regeneration
+
+        command="cargo run -- inventory --name $TESTNET_NAME --force-regeneration"
+        [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME"
+        eval $command
 
 branding:
   icon: "globe"


### PR DESCRIPTION
The `inventory` command for `testnet-deploy` accepts an argument for the network contacts file name output. By exposing this argument on the print inventory workflow, we can generate a new network contacts file after a testnet has already been deployed. This is useful if the network contacts file was not uploaded with the correct name.