### PR TITLE
feat: provide vm and bootstrap node count inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,39 @@ Obviously, you need to substitute the job names here with your own.
 
 # Inputs
 
-|Input|Description|Required|Default|
-|---|---|:---:|:---:|
-|`do-token`|Digital Ocean Access Token|`true`|-|
-|`aws-access-key-id`|AWS Access Key ID|`true`|-|
-|`aws-access-key-secret`|AWS Access Key Secret|`true`|-|
-|`aws-default-region`|AWS Default region|`false`|`eu-west-2`|
-|`ssh-secret-key`|SSH key used to run the nodes on the Digital Ocean droplets|`true`|-|
-|`node-count`|Number of nodes to be deployed|`false`|`50`|
-|`node-path`|Path to the node binary|`false`*||
-|`node-version`|Node version|`false`*||
-|`build-node`|Should the node binary be built? Accepts `true` or `false`|`false`*|`false`|
-|`action`|Task to be carried out. Accepts `create` or `destroy`|`false`|`create`|
-
-
-`*` - Either `node-path` or `node-version` should be provided or `build-node` should be set to `true`. <br>
-If both `node-path` and `node-version` are supplied `node-version` takes precedence. `build-node` overrides both of them.
+| Name                      | Description                                                                                                            | Required | Default       |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| action                    | Accepts 'create', 'destroy', 'resources', 'logs', 'list-inventory', 'print-inventory'.                                 | true     |               |
+| ansible-vault-password    | Password for Ansible vault.                                                                                            | true     |               |
+| ansible-verbose           | Set to use verbose output for Ansible                                                                                  | true     | false         |
+| aws-access-key-id         | AWS access key ID                                                                                                      |          |               |
+| aws-access-key-secret     | AWS access key                                                                                                         |          |               |
+| aws-region                | AWS region                                                                                                             |          | eu-west-2     |
+| beta-encryption-key       | Supply an encryption key that will be used with the auditor.                                                           |          |               |
+| bootstrap-node-vm-count   | Number of bootstrap node VMs to be deployed                                                                            |          |               |
+| do-token                  | Digital Ocean Authorization token                                                                                      | true     |               |
+| faucet-version            | Supply a version for the faucet. Otherwise the latest will be used.                                                    |          |               |
+| log-format                | Set the log format for the nodes, can be 'json' or 'default'. Defaults to 'default' if not set.                        |          | default       |
+| network-contacts-file-name| Provide a name for the network contacts file                                                                           |          |               |
+| node-count                | Number of nodes service instances to be started                                                                        |          |               |
+| node-vm-count             | Number of node VMs to be deployed                                                                                      |          |               |
+| public-rpc                | Set to make node manager RPC daemons publicly accessible                                                               | true     | false         |
+| protocol-version          | The network protocol version can be set to 'restricted' or any custom version string.                                  |          |               |
+| provider                  | The cloud provider. Accepts 'aws' or 'digital-ocean'.                                                                  | true     |               |
+| re-attempts               | The number of times to re-run testnet-deploy in case of failures.                                                      |          | "0"           |
+| rust-log                  | Set RUST_LOG to this value for testnet-deploy                                                                          | false    |               |
+| safenode-features         | Comma-separated list of features to be used when building a branch of safenode                                         |          |               |
+| safenode-version          | Supply a version for safenode. Otherwise the latest will be used.                                                      |          |               |
+| safenode-manager-version  | Supply a version for safenode-manager. Otherwise the latest will be used.                                              |          |               |
+| safe-network-branch       | Build binaries from the specified safe_network branch. The testnet will use these binaries.                            |          |               |
+| safe-network-user         | Build binaries from the safe_network repository owned by this org or username. The testnet will use these binaries.    |          |               |
+| ssh-secret-key            | SSH key used to run the nodes on the Digital Ocean droplets                                                            |          |               |
+| subnet-id                 | If running on AWS, this is the subnet of the VPC on which the VMs will be created.                                     |          |               |
+| security-group-id         | If running on AWS, this is the ID of the security groups the VMs will use.                                             |          |               |
+| testnet-name              | The name of the testnet.                                                                                               | true     |               |
+| testnet-deploy-branch     | The branch for the sn-testnet-deploy repository. Enables using forks to test changes for testnet-deploy.               |          | main          |
+| testnet-deploy-user       | The user or organisation for the sn-testnet-deploy repository. Enables using forks to test changes for testnet-deploy. |          | maidsafe      |
+| uploader-vm-count         | Number of uploader VMs to be deployed                                                                                  |          |               |
 
 # License
 

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,12 @@ inputs:
   aws-region:
     description: AWS region
     default: eu-west-2
-  bootstrap-peer:
-    description: Optional starting contact for the network. If this is supplied no genesis, faucet or audit nodes will be created.
-    required: false
   beta-encryption-key:
     description: Supply an encryption key that will be used with the auditor.
+  bootstrap-node-count:
+    description: Number of node services to run on each bootstrap node VM
+  bootstrap-node-vm-count:
+    description: Number of bootstrap node VMs to be deployed
   do-token:
     description: Digital Ocean Authorization token
     required: true
@@ -35,7 +36,9 @@ inputs:
   network-contacts-file-name:
     description: Provide a name for the network contacts file
   node-count:
-    description: Number of nodes service instances to be started
+    description: Number of node services to run on each node VM
+  node-vm-count:
+    description: Number of node VMs to be deployed
   public-rpc:
     description: Set to make node manager RPC daemons publicly accessible
     required: true
@@ -83,8 +86,8 @@ inputs:
       The user or organisation for the sn-testnet-deploy repository. Enables using forks to test
       changes for testnet-deploy.
     default: maidsafe
-  vm-count:
-    description: Number of node VMs to be deployed
+  uploader-vm-count:
+    description: Number of uploader VMs to be deployed
 
 runs:
   using: composite
@@ -121,9 +124,6 @@ runs:
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
         DO_PAT: ${{ inputs.do-token }}
-        NODE_COUNT: ${{ inputs.node-count }}
-        PROVIDER: ${{ inputs.provider }}
-        RUST_LOG: ${{ inputs.rust-log }}
         SAFE_NETWORK_BRANCH: ${{ inputs.safe-network-branch }}
         SAFE_NETWORK_USER: ${{ inputs.safe-network-user }}
         SN_TESTNET_DEV_SECURITY_GROUP_ID: ${{ inputs.security-group-id }}
@@ -131,8 +131,6 @@ runs:
         TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
         TESTNET_DEPLOY_BRANCH: ${{ inputs.testnet-deploy-branch }}
         TESTNET_DEPLOY_USER: ${{ inputs.testnet-deploy-user }}
-        TESTNET_NAME: ${{ inputs.testnet-name }}
-        VM_COUNT: ${{ inputs.vm-count }}
       run: |
         set -e
 
@@ -181,11 +179,13 @@ runs:
         ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         BETA_ENCRYPTION_KEY: ${{ inputs.beta-encryption-key }}
-        BOOTSTRAP_PEER: ${{ inputs.bootstrap-peer }}
+        BOOTSTRAP_NODE_COUNT: ${{ inputs.bootstrap-node-count }}
+        BOOTSTRAP_NODE_VM_COUNT: ${{ inputs.bootstrap-node-vm-count }}
         FAUCET_VERSION: ${{ inputs.faucet-version }}
         LOG_FORMAT: ${{ inputs.log-format }}
         NETWORK_CONTACTS_FILE_NAME: ${{ inputs.network-contacts-file-name }}
         NODE_COUNT: ${{ inputs.node-count }}
+        NODE_VM_COUNT: ${{ inputs.node-vm-count }}
         PROTOCOL_VERSION: ${{ inputs.protocol-version }}
         PROVIDER: ${{ inputs.provider }}
         PUBLIC_RPC: ${{ inputs.public-rpc }}
@@ -197,7 +197,7 @@ runs:
         SAFE_NETWORK_BRANCH: ${{ inputs.safe-network-branch }}
         SAFE_NETWORK_USER: ${{ inputs.safe-network-user }}
         TESTNET_NAME: ${{ inputs.testnet-name }}
-        VM_COUNT: ${{ inputs.vm-count }}
+        UPLOADER_VM_COUNT: ${{ inputs.uploader-vm-count }}
       shell: bash
       run: |
         set -e
@@ -206,15 +206,16 @@ runs:
 
         command="cargo run -- deploy \
           --name $TESTNET_NAME \
-          --provider $PROVIDER \
-          --node-count $NODE_COUNT \
-          --vm-count $VM_COUNT "
+          --provider $PROVIDER "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $BETA_ENCRYPTION_KEY ]] && command="$command --beta-encryption-key $BETA_ENCRYPTION_KEY "
-        [[ -n $BOOTSTRAP_PEER ]] && command="$command --bootstrap-peer $BOOTSTRAP_PEER "
+        [[ -n $BOOTSTRAP_NODE_COUNT ]] && command="$command --bootstrap-node-count $BOOTSTRAP_NODE_COUNT "
+        [[ -n $BOOTSTRAP_NODE_VM_COUNT ]] && command="$command --bootstrap-node-vm-count $BOOTSTRAP_NODE_VM_COUNT "
         [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
         [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
         [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME "
+        [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_VM_COUNT "
+        [[ -n $NODE_VM_COUNT ]] && command="$command --node-vm-count $NODE_VM_COUNT "
         [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION "
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "
         [[ -n $SAFENODE_FEATURES ]] && command="$command --safenode-features $SAFENODE_FEATURES "
@@ -222,6 +223,7 @@ runs:
         [[ -n $SAFENODE_MANAGER_VERSION ]] && command="$command --safenode-manager-version $SAFENODE_MANAGER_VERSION "
         [[ -n $SAFE_NETWORK_BRANCH ]] && command="$command --branch $SAFE_NETWORK_BRANCH "
         [[ -n $SAFE_NETWORK_USER ]] && command="$command --repo-owner $SAFE_NETWORK_USER "
+        [[ -n $UPLOADER_VM_COUNT ]] && command="$command --uploader-vm-count $UPLOADER_VM_COUNT "
 
         max_attempts=$((RETRY_ATTEMPTS + 1)) # +1 as default retry_attempts is 0
         for i in $(seq 1 $max_attempts); do


### PR DESCRIPTION
  Three new VM inputs are introduced: bootstrap-node-vm-count, node-vm-count, uploader-vm-count. As
  the names imply, they control the number of VMs for each of those categories. A deployment now
  includes bootstrap nodes and 'normal' nodes, as well as uploader machines. The `bootstrap-peer`
  input is removed because two deploy runs are not required.

  A fourth input is also added: `bootstrap-node-count`. It controls the number of node services that
  run on the bootstrap VMs, allowing that to be changed independently of the number that run on
  generic nodes, which is much larger.