### PR TITLE
feat: provide `ansible-forks` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
         [[ -n $FAUCET_VERSION ]] && command="$command --faucet-version $FAUCET_VERSION "
         [[ -n $LOG_FORMAT ]] && command="$command --log-format $LOG_FORMAT "
         [[ -n $NETWORK_CONTACTS_FILE_NAME ]] && command="$command --network-contacts-file-name $NETWORK_CONTACTS_FILE_NAME "
-        [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_VM_COUNT "
+        [[ -n $NODE_COUNT ]] && command="$command --node-count $NODE_COUNT "
         [[ -n $NODE_VM_COUNT ]] && command="$command --node-vm-count $NODE_VM_COUNT "
         [[ -n $PROTOCOL_VERSION ]] && command="$command --protocol-version $PROTOCOL_VERSION "
         [[ $PUBLIC_RPC == "true" ]] && command="$command --public-rpc "

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,8 @@ inputs:
       Task to be carried out.
       Accepts 'create', 'destroy', 'resources', 'logs', 'list-inventory', 'print-inventory'.
     required: true
+  ansible-forks:
+    description: The number of forks to use with Ansible
   ansible-vault-password:
     description: Password for Ansible vault.
     required: true
@@ -176,6 +178,7 @@ runs:
     - name: Create testnet
       if: inputs.action == 'create'
       env:
+        ANSIBLE_FORKS: ${{ inputs.ansible-forks }}
         ANSIBLE_VERBOSE: ${{ inputs.ansible-verbose }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         BETA_ENCRYPTION_KEY: ${{ inputs.beta-encryption-key }}
@@ -207,6 +210,7 @@ runs:
         command="cargo run -- deploy \
           --name $TESTNET_NAME \
           --provider $PROVIDER "
+        [[ -n $ANSIBLE_FORKS ]] && command="$command --forks $ANSIBLE_FORKS "
         [[ $ANSIBLE_VERBOSE == "true" ]] && command="$command --ansible-verbose "
         [[ -n $BETA_ENCRYPTION_KEY ]] && command="$command --beta-encryption-key $BETA_ENCRYPTION_KEY "
         [[ -n $BOOTSTRAP_NODE_COUNT ]] && command="$command --bootstrap-node-count $BOOTSTRAP_NODE_COUNT "


### PR DESCRIPTION
- c23c726 **feat: provide `ansible-forks` input**

  This can be used to control the amount of parallel SSH connections made by Ansible during the
  deploy.

- 2583289 **fix: pass correct node count value**

  The node count was being passed the `NODE_VM_COUNT` value rather than `NODE_COUNT`.